### PR TITLE
Bump `ghostwriter/clock` from `3.0.0` to `3.0.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require": {
         "php": ">=8.3",
         "ghostwriter/case-converter": "^1.0.0",
-        "ghostwriter/clock": "^3.0.0",
+        "ghostwriter/clock": "^3.0",
         "ghostwriter/collection": "^2.0.0",
         "ghostwriter/config": "^0.4.1",
         "ghostwriter/container": "^4.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "38ab008ada2325d5778e5ec7e32ce35e",
+    "content-hash": "ee1d537447e4bf82a2a7c31dcd222888",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -81,16 +81,16 @@
         },
         {
             "name": "ghostwriter/clock",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/clock.git",
-                "reference": "906ded66d7dda723531aa7b0d3554f9026304d3b"
+                "reference": "e68368475feb957b7d40e3d1e03de411fe6b032d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/clock/zipball/906ded66d7dda723531aa7b0d3554f9026304d3b",
-                "reference": "906ded66d7dda723531aa7b0d3554f9026304d3b",
+                "url": "https://api.github.com/repos/ghostwriter/clock/zipball/e68368475feb957b7d40e3d1e03de411fe6b032d",
+                "reference": "e68368475feb957b7d40e3d1e03de411fe6b032d",
                 "shasum": ""
             },
             "require": {
@@ -98,12 +98,12 @@
             },
             "require-dev": {
                 "ghostwriter/coding-standard": "dev-main",
-                "ghostwriter/psalm-plugin": "^0.2.0"
+                "ghostwriter/psalm-plugin": "dev-main"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Ghostwriter\\Clock\\": "src"
+                    "Ghostwriter\\Clock\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -125,8 +125,6 @@
                 "ghostwriter"
             ],
             "support": {
-                "docs": "https://github.com/ghostwriter/clock",
-                "forum": "https://github.com/ghostwriter/clock/discussions",
                 "issues": "https://github.com/ghostwriter/clock/issues",
                 "rss": "https://github.com/ghostwriter/clock/releases.atom",
                 "security": "https://github.com/ghostwriter/clock/security/advisories/new",
@@ -138,7 +136,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-06-21T23:42:37+00:00"
+            "time": "2025-01-05T19:26:41+00:00"
         },
         {
             "name": "ghostwriter/collection",
@@ -4653,7 +4651,7 @@
     "platform": {
         "php": ">=8.3"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.3.999"
     },


### PR DESCRIPTION
Bumps `ghostwriter/clock` from `3.0.0` to `3.0.1`.

- Update `composer.json`
- Update `composer.lock`