### PR TITLE
Update boundwize/structarmed to version 0.6.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.6.10",
+        "boundwize/structarmed": "^0.6.13",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f3ba314dc76da2f2230d587ecdab7c83",
+    "content-hash": "70e1e2dca50637818f8ec1ebba5bf66f",
     "packages": [
         {
             "name": "ghostwriter/container",
@@ -295,16 +295,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.6.10",
+            "version": "0.6.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "893d7fb54627be9bfc127fbddaaaa1921fd026aa"
+                "reference": "7a6e3a9e4b8e7ae6cb344c5933240a8d71dd62bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/893d7fb54627be9bfc127fbddaaaa1921fd026aa",
-                "reference": "893d7fb54627be9bfc127fbddaaaa1921fd026aa",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/7a6e3a9e4b8e7ae6cb344c5933240a8d71dd62bc",
+                "reference": "7a6e3a9e4b8e7ae6cb344c5933240a8d71dd62bc",
                 "shasum": ""
             },
             "require": {
@@ -353,7 +353,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.6.10"
+                "source": "https://github.com/boundwize/structarmed/tree/0.6.13"
             },
             "funding": [
                 {
@@ -361,7 +361,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-19T10:47:01+00:00"
+            "time": "2026-05-19T15:51:33+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -430,16 +430,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "7cd775e1b9f3bcf6c31712bd6e7597123147a674"
+                "reference": "1edf464ea9689e52d936975bbf61f76e38a2d416"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/7cd775e1b9f3bcf6c31712bd6e7597123147a674",
-                "reference": "7cd775e1b9f3bcf6c31712bd6e7597123147a674",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/1edf464ea9689e52d936975bbf61f76e38a2d416",
+                "reference": "1edf464ea9689e52d936975bbf61f76e38a2d416",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.6.9",
+                "boundwize/structarmed": "^0.6.13",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -550,7 +550,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-19T08:49:35+00:00"
+            "time": "2026-05-19T20:24:27+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.6.10` to `0.6.13`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`