### PR TITLE
Update boundwize/structarmed to version 0.7.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.7.10",
+        "boundwize/structarmed": "^0.7.11",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/testify": "^0.1.1",
         "mockery/mockery": "^1.6.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "50deb8c2d2ecec260d95fe0374f0b56b",
+    "content-hash": "36ecc2bb74f7f3951a6d316b76505e5d",
     "packages": [
         {
             "name": "ghostwriter/container",
@@ -295,16 +295,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.7.10",
+            "version": "0.7.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "35c3929ce13f726ae5384773d7272fc402b0366d"
+                "reference": "b8ead2b5fd9a62f9c98bb6d92c440215ca512b47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/35c3929ce13f726ae5384773d7272fc402b0366d",
-                "reference": "35c3929ce13f726ae5384773d7272fc402b0366d",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/b8ead2b5fd9a62f9c98bb6d92c440215ca512b47",
+                "reference": "b8ead2b5fd9a62f9c98bb6d92c440215ca512b47",
                 "shasum": ""
             },
             "require": {
@@ -357,7 +357,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.7.10"
+                "source": "https://github.com/boundwize/structarmed/tree/0.7.11"
             },
             "funding": [
                 {
@@ -365,7 +365,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-25T12:23:38+00:00"
+            "time": "2026-05-25T22:59:15+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -523,12 +523,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "eefd6f57c2aecfe81fe28f1faf3891428da5e776"
+                "reference": "2bdc20814da0fd448a4edf5c5250b581d73cf88f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/eefd6f57c2aecfe81fe28f1faf3891428da5e776",
-                "reference": "eefd6f57c2aecfe81fe28f1faf3891428da5e776",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/2bdc20814da0fd448a4edf5c5250b581d73cf88f",
+                "reference": "2bdc20814da0fd448a4edf5c5250b581d73cf88f",
                 "shasum": ""
             },
             "require": {
@@ -580,7 +580,7 @@
                 "ext-zlib": "*",
                 "mockery/mockery": "^1.6.12",
                 "php": "~8.4.0 || ~8.5.0",
-                "phpunit/phpunit": "^13.1.11",
+                "phpunit/phpunit": "^13.1.12",
                 "symfony/var-dumper": "^8.0.8"
             },
             "conflict": {
@@ -643,7 +643,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-25T15:06:57+00:00"
+            "time": "2026-05-25T20:46:31+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.7.10` to `0.7.11`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`