### PR TITLE
Update boundwize/structarmed to version 0.7.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.7.11",
+        "boundwize/structarmed": "^0.7.12",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/testify": "^0.1.1",
         "mockery/mockery": "^1.6.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "36ecc2bb74f7f3951a6d316b76505e5d",
+    "content-hash": "a0952d897a3ddd225c76e7d5be892a27",
     "packages": [
         {
             "name": "ghostwriter/container",
@@ -295,16 +295,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.7.11",
+            "version": "0.7.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "b8ead2b5fd9a62f9c98bb6d92c440215ca512b47"
+                "reference": "4932aa4d395e6ddf7dd372f8bf85a41213715bdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/b8ead2b5fd9a62f9c98bb6d92c440215ca512b47",
-                "reference": "b8ead2b5fd9a62f9c98bb6d92c440215ca512b47",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/4932aa4d395e6ddf7dd372f8bf85a41213715bdf",
+                "reference": "4932aa4d395e6ddf7dd372f8bf85a41213715bdf",
                 "shasum": ""
             },
             "require": {
@@ -357,7 +357,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.7.11"
+                "source": "https://github.com/boundwize/structarmed/tree/0.7.12"
             },
             "funding": [
                 {
@@ -365,7 +365,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-25T22:59:15+00:00"
+            "time": "2026-05-26T14:14:49+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.7.11` to `0.7.12`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`